### PR TITLE
Remove list of dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,6 @@ NCEP/EMC developers.
 
 Code manager: Kyle Gerheiser, Hang Lei
 
-## Prerequisites
-
-This package requires the following libraries:
-- [NCEPLIBS-bacio](https://github.com/NOAA-EMC/NCEPLIBS-bacio)
-- [NCEPLIBS-w3nco](https://github.com/NOAA-EMC/NCEPLIBS-w3nco)
-- [NCEPLIBS-sigio](https://github.com/NOAA-EMC/NCEPLIBS-sigio)
-- [NCEPLIBS-nemsio](https://github.com/NOAA-EMC/NCEPLIBS-nemsio)
-
 ## Installing
 
 ```


### PR DESCRIPTION
With removal of gblevents w3emc has no dependencies.

Fix #76 