### PR TITLE
Add IntelLLVM support

### DIFF
--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -21,10 +21,9 @@ defaults:
 jobs:
   Intel:
     runs-on: ubuntu-latest
-    env:
-      CC: icc
-      FC: ifort
-      CXX: icpc
+    strategy:
+      matrix:
+        compilers: ["CC=icc FC=ifort","CC=icx FC=ifx"]
 
     steps:
 
@@ -51,7 +50,7 @@ jobs:
       run: |
         cd bacio
         mkdir build && cd build
-        cmake .. -DCMAKE_INSTALL_PREFIX=~/bacio
+        ${{ matrix.compilers }} cmake .. -DCMAKE_INSTALL_PREFIX=~/bacio
         make -j2
         make install
 
@@ -67,14 +66,14 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/bufr
-        key: bufr-Linux_options_${{ runner.os }}-v11.7.1
+        key: bufr-intel-${{ matrix.compilers }}-${{ runner.os }}-v11.7.1
 
     - name: build-bufr
       if: steps.cache-bufr.outputs.cache-hit != 'true'
       run: |
         cd bufr
         mkdir build && cd build
-        cmake -DCMAKE_INSTALL_PREFIX=~/bufr ..
+        ${{ matrix.compilers }} cmake -DCMAKE_INSTALL_PREFIX=~/bufr ..
         make -j2
         make install
 
@@ -87,7 +86,7 @@ jobs:
       run: |
         cd w3emc
         mkdir build && cd build
-        cmake -DOPENMP=ON -DCMAKE_PREFIX_PATH="~/bacio;~/bufr" ..
+        ${{ matrix.compilers }} cmake -DCMAKE_PREFIX_PATH="~/bacio;~/bufr" ..
         make -j2
 
     - name: test-w3emc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ else()
 endif()
 
 # Set compiler flags.
-if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel|IntelLLVM)$")
   set(CMAKE_Fortran_FLAGS "-g -traceback ${CMAKE_Fortran_FLAGS}")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O2")
   set(fortran_d_flags "-r8")


### PR DESCRIPTION
This PR adds IntelLLVM (OneAPI) support, including CI testing.

Fixes #188

With OneAPI support for bacio and w3emc, we can switch prod_util over to using w3emc and add OneAPI support in one move.