### PR TITLE
Update developer.yml to 'gcc'/'gfortran'

### DIFF
--- a/.github/workflows/Linux_options.yml
+++ b/.github/workflows/Linux_options.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   Linux_options:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         options: ['-DBUILD_D=OFF -DBUILD_8=ON', '-DBUILD_4=OFF -DBUILD_DEPRECATED=ON -DBUILD_WITH_BUFR=ON', '-DBUILD_SHARED_LIBS=ON']

--- a/.github/workflows/Linux_versions.yml
+++ b/.github/workflows/Linux_versions.yml
@@ -17,8 +17,8 @@ jobs:
   Linux_versions:
     runs-on: ubuntu-latest
     env:
-      FC: gfortran-11
-      CC: gcc-11
+      FC: gfortran
+      CC: gcc
     strategy:
       matrix:
         bacio-version: [2.4.1, 2.5.0, 2.6.0]

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -17,8 +17,8 @@ jobs:
   developer:
     runs-on: ubuntu-latest
     env:
-      FC: gfortran-11
-      CC: gcc-11
+      FC: gfortran
+      CC: gcc
 
     steps:
     


### PR DESCRIPTION
This PR changes developer.yml & Linux*yml to use the default gcc for the ubuntu-latest runner.