### PR TITLE
Add CDash workflow

### DIFF
--- a/.github/workflows/cdash.yml
+++ b/.github/workflows/cdash.yml
@@ -1,0 +1,27 @@
+name: cdash
+on:
+  push:
+    branches:
+    - develop
+    - add_cdash
+
+jobs:
+  cdash:
+    runs-on: ubuntu-latest
+
+    env:
+      FC: gfortran
+      CC: gcc
+      CDASH_TOKEN: ${{ secrets.CDASH_TOKEN }}
+
+    steps:
+
+    - name: "Build dependencies"
+      uses: NOAA-EMC/ci-build-nceplibs@oneinstalldir
+      with:
+        bacio-version: develop
+
+    - name: CDash
+      uses: NOAA-EMC/ci-cdash@develop
+      with:
+        extra-cmake-options: -DBUILD_8=ON -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/nceplibs

--- a/spack/package.py
+++ b/spack/package.py
@@ -93,5 +93,5 @@ class W3emc(CMakePackage):
         return args
 
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             make("test")


### PR DESCRIPTION
This PR adds a CI job that creates CDash info and pushes it to https://my.cdash.org/index.php?project=NCEPLIBS-w3emc each time a commit is merged into develop.

Successful run: https://github.com/AlexanderRichert-NOAA/NCEPLIBS-w3emc/actions/runs/14388059603/job/40348228004