### PR TITLE
CI: add cron's and workflow_dispatch's

### DIFF
--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 jobs:
   Intel:

--- a/.github/workflows/Linux_options.yml
+++ b/.github/workflows/Linux_options.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 jobs:
   Linux_options:

--- a/.github/workflows/Linux_versions.yml
+++ b/.github/workflows/Linux_versions.yml
@@ -12,6 +12,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 jobs:
   Linux_versions:

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 jobs:
   MacOS:

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -23,7 +23,7 @@ jobs:
       FC: ${{ matrix.compiler }}
     strategy:
       matrix:
-        compiler: [gfortran-12]
+        compiler: [gfortran-14]
         bacio-version: [2.4.1, 2.5.0, 2.6.0]
 
     steps:

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -14,6 +14,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 jobs:
   # This job builds with Spack, exercising all variants, and runs the CTest suite each time

--- a/.github/workflows/cdash.yml
+++ b/.github/workflows/cdash.yml
@@ -4,6 +4,7 @@ on:
     branches:
     - develop
     - add_cdash
+  workflow_dispatch:
 
 jobs:
   cdash:

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -12,6 +12,11 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run biweekly
+    - cron: '0 0 1 * *'
+    - cron: '0 0 15 * *'
+  workflow_dispatch:
 
 jobs:
   developer:


### PR DESCRIPTION
This PR updates CI workflows to run on cron's: biweekly for 'developer' workflow, monthly for the rest. It also adds workflow_dispatch triggers to enable running workflows manually.

Part of https://github.com/NOAA-EMC/NCEPLIBS/issues/237