### PR TITLE
Add support for LLVM flang-new, fix non-conforming calls to transfer intrinsic

### DIFF
--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        variants: ["+pic +shared precision=d", "~pic ~shared precision=4", "+pic ~shared precision=8"]
+        variants: ["+shared precision=d", "~pic precision=4", "~shared precision=8"]
 
     runs-on: ${{ matrix.os }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(LLVMFlang)$")
   set(CMAKE_Fortran_FLAGS
       "-g -funroll-loops ${CMAKE_Fortran_FLAGS}")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O2")
-  set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -Wall")
+  set(CMAKE_Fortran_FLAGS_DEBUG "-O0")
   set(fortran_d_flags "-fdefault-real-8")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
   set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fuse-ld=lld")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,14 @@ elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O2")
   set(CMAKE_Fortran_FLAGS_DEBUG "-ggdb -Wall")
   set(fortran_d_flags "-fdefault-real-8")
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(LLVMFlang)$")
+  set(CMAKE_Fortran_FLAGS
+      "-g -funroll-loops ${CMAKE_Fortran_FLAGS}")
+  set(CMAKE_Fortran_FLAGS_RELEASE "-O2")
+  set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -Wall")
+  set(fortran_d_flags "-fdefault-real-8")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
+  set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fuse-ld=lld")
 endif()
 
 # Deal with argument mismatch on GNU compilers version 10 or later.

--- a/spack/package.py
+++ b/spack/package.py
@@ -1,7 +1,8 @@
-# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
-# Spack Project Developers. See the top-level COPYRIGHT file for details.
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *
 
@@ -38,7 +39,7 @@ class W3emc(CMakePackage):
         description="Set precision (_4/_d/_8 library versions)",
         when="@2.10:",
     )
-    variant("shared", default=False, description="Build shared library", when="@2.10:")
+    variant("shared", default=False, description="Build shared library", when="@2.10: +pic")
     variant(
         "extradeps",
         default=False,
@@ -53,17 +54,19 @@ class W3emc(CMakePackage):
     )
 
     conflicts("+shared +extradeps", msg="Shared library cannot be built with unknown dependencies")
-    conflicts("+shared ~pic", msg="Shared library requires PIC")
+
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
 
     depends_on("bufr", when="@2.10: +bufr")
-    depends_on("bacio", when="@2.9.2:")
+    depends_on("bacio@2.4:", when="@2.9.2:")
 
     # w3emc 2.7.3 contains gblevents which has these dependencies
     depends_on("nemsio", when="@2.7.3")
     depends_on("sigio", when="@2.7.3")
     depends_on("netcdf-fortran", when="@2.7.3")
 
-    def setup_run_environment(self, env):
+    def setup_run_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("@:2.9"):
             suffixes = ("4", "d", "8")
             shared = False

--- a/tests/test_gbytec.F90
+++ b/tests/test_gbytec.F90
@@ -164,7 +164,7 @@ program test_gbytec
   nskip = 0
   num = 1
   r_in(1) = 1
-  in = transfer(r_in, in)
+  in = transfer(r_in, in, size(in))
   call sbytesc(out4, in, iskip, nbits, nskip, num)
   ! Note that the 32-bit IEEE representation of 1.0 is 3f800000. The
   ! decimal for 3f is 63, the decimal for 80 is 128.
@@ -197,7 +197,7 @@ program test_gbytec
   num = 2
   r_in2(1) = 1 
   r_in2(2) = 1 
-  in = transfer(r_in2, in2)
+  in2 = transfer(r_in2, size(in2))
   call sbytesc(out8, in2, iskip, nbits, nskip, num)
   ! Note that the 32-bit IEEE representation of 1.0 is 3f800000. The
   ! decimal for 3f is 63, the decimal for 80 is 128.

--- a/tests/test_w3fi73.F90
+++ b/tests/test_w3fi73.F90
@@ -39,7 +39,7 @@ program test_w3fi73
   call w3fi73(ibflag, ibmap, iblen, bms, lenbms, ierr)
   if (ierr .ne. 0) stop 4
   if (lenbms .ne. 8) stop 5
-  cbms = transfer(bms, cbms)
+  cbms = transfer(bms, cbms, size(cbms))
   do i = 1, 8
      print *, ichar(cbms(i))
      if (ichar(cbms(i)) .ne. expected_cbms(i)) stop 100


### PR DESCRIPTION
## Description

This PR adds support for compiling with LLVM flang-new (tested 21.1.0) and fixes non-conforming calls to the `transfer` intrinsic reported in #250.

I compiled and ran the tests like this:
```
mkdir build && cd build
cmake --fresh -DBUILD_DEPRECATED=ON -DBUILD_4=ON -DBUILD_D=ON -DBUILD_8=ON .. 2>&1 | tee log.cmake
make VERBOSE=1 2>&1 | tee log.make
ctest

cd ..
mkdir build-debug && cd build-debug
cmake --fresh -DCMAKE_BUILD_TYPE=Debug -DBUILD_DEPRECATED=ON -DBUILD_4=ON -DBUILD_D=ON -DBUILD_8=ON .. 2>&1 | tee log.cmake
make VERBOSE=1 2>&1 | tee log.make
ctest
```
In both cases: `100% tests passed, 0 tests failed out of 57`

## Issues

Closes #250 
Closes #246