### PR TITLE
Add compiler flags for NVHPC to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,12 @@ elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(LLVMFlang)$")
   set(fortran_d_flags "-fdefault-real-8")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
   set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fuse-ld=lld")
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(NVHPC)$")
+  set(CMAKE_Fortran_FLAGS
+      "-g ${CMAKE_Fortran_FLAGS}")
+  set(CMAKE_Fortran_FLAGS_RELEASE "-O2")
+  set(CMAKE_Fortran_FLAGS_DEBUG "-O0")
+  set(fortran_d_flags "-r8")
 endif()
 
 # Deal with argument mismatch on GNU compilers version 10 or later.
@@ -99,5 +105,5 @@ endif()
 # Determine whether or not to generate documentation.
 if(ENABLE_DOCS)
   find_package(Doxygen REQUIRED)
-  add_subdirectory(docs)  
+  add_subdirectory(docs)
 endif()


### PR DESCRIPTION
### Description
This PR adds compiler flags for NVHPC (Nvidia compilers)

### Issues addressed
_Use "Fixes #xxx" to auto-close issue on merge_

### Generative AI disclosure (required)
> [!IMPORTANT]
> _If LLM/generative AI tools were used to create any of the changes in this PR, please update the placeholder text below. If your AI-generated code has been reviewed and validated by **NWS staff** (including yourself), check the box, otherwise only update the AI tool name and leave the box unchecked until the PR is reviewed._
- [ ] **[Insert AI tool name]** was used to assist with developing this code. The code has been reviewed, edited, and validated by NWS staff.
- [x] No generative AI tools were used to develop any of the code in this PR.
